### PR TITLE
Use HTML5 audio instead of Web Audio API

### DIFF
--- a/src/client/scripts/helpers/Player.js
+++ b/src/client/scripts/helpers/Player.js
@@ -34,7 +34,7 @@ class Player {
     // Prepare sound
     const howl = new Howl({
       src: [encodeURI(file)],
-      // html5: true, // Use HTML5 Audio, so large files can be streamed
+      html5: true,
       preload: false,
     });
 

--- a/src/server/Controller/SamplesController.php
+++ b/src/server/Controller/SamplesController.php
@@ -43,7 +43,9 @@ class SamplesController extends Controller
 
 		readfile($path);
 
-		return $response->withHeader('Content-Type', $mimeType);
+		return $response
+      ->withHeader('Content-Type', $mimeType)
+      ->withHeader('Accept-Ranges', 'bytes');
 	}
 
 	public function queryAction(Request $request, Response $response, $arguments)


### PR DESCRIPTION
@villermen, can you test this on the production server?
If it works, it was an _incredibly_ easy solution for https://github.com/villermen/soundboard/issues/52.
